### PR TITLE
Refine pagination logic in notes retrieval

### DIFF
--- a/src/routes/chatLlm/chatLlmCrud/chatLlmCrud.route.ts
+++ b/src/routes/chatLlm/chatLlmCrud/chatLlmCrud.route.ts
@@ -22,11 +22,12 @@ router.post('/notesGet', middlewareUserAuth, async (req: Request, res: Response)
         }
 
         // Pagination parameters
+        const minLimitPerRequest = 10;
         let limit = 50; // Default limit
         let skip = 0; // Default skip (0 means most recent messages)
 
         if (typeof req.body?.limit === 'number' && req.body.limit > 0) {
-            limit = Math.min(req.body.limit, 200); // Max 200 messages per request
+            limit = Math.max(req.body.limit, minLimitPerRequest);
         }
 
         if (typeof req.body?.skip === 'number' && req.body.skip >= 0) {


### PR DESCRIPTION
Refine pagination logic in notes retrieval: Updated the limit handling in the notesGet route to ensure a minimum limit of 10 messages per request, enhancing the pagination functionality and improving user experience in message retrieval.